### PR TITLE
Fixed di:compile issue with test case

### DIFF
--- a/dev/Helper/ConfigTest.php
+++ b/dev/Helper/ConfigTest.php
@@ -14,7 +14,7 @@ class ConfigTest
     /** @var \Flancer32\BotSess\Helper\Config */
     private $obj;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /** Get object to test */
         $obm = \Magento\Framework\App\ObjectManager::getInstance();


### PR DESCRIPTION
Fix for the above issue.

```
Fatal error:  Declaration of Test\Flancer32\BotSess\Helper\ConfigTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in /app/vendor/flancer32/mage2_ext_bot_sess/dev/Helper/ConfigTest.php on line 17
```